### PR TITLE
fix incorrect length on tracker_register packet

### DIFF
--- a/d2/main/net_udp.c
+++ b/d2/main/net_udp.c
@@ -604,7 +604,7 @@ int udp_tracker_unregister()
 int udp_tracker_register()
 {
 	// Variables
-	int iLen = 14;
+	int iLen = 15;
 	ubyte pBuf[iLen];
 	
 	// Reset the last tracker message


### PR DESCRIPTION
Fixing the length of the buffer used for the D2 tracker_register packet. This is already fixed in D1.
