### PR TITLE
Adds a new "mouse overrun buffer" setting

### DIFF
--- a/d1/main/kconfig.h
+++ b/d1/main/kconfig.h
@@ -30,6 +30,7 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 typedef struct _control_info {
 	float key_pitch_forward_down_time, key_pitch_backward_down_time, key_heading_left_down_time, key_heading_right_down_time, key_slide_left_down_time, key_slide_right_down_time, key_slide_up_down_time, key_slide_down_down_time, key_bank_left_down_time, key_bank_right_down_time; // to scale movement depending on how long the key is pressed
 	fix pitch_time, vertical_thrust_time, heading_time, sideways_thrust_time, bank_time, forward_thrust_time;
+    fix pitch_time_overrun, vertical_thrust_time_overrun, heading_time_overrun, sideways_thrust_time_overrun, bank_time_overrun, forward_thrust_time_overrun;
 	ubyte key_pitch_forward_state, key_pitch_backward_state, key_heading_left_state, key_heading_right_state, key_slide_left_state, key_slide_right_state, key_slide_up_state, key_slide_down_state, key_bank_left_state, key_bank_right_state; // to scale movement for keys only we need them to be seperate from joystick/mouse buttons
 	ubyte btn_slide_left_state, btn_slide_right_state, btn_slide_up_state, btn_slide_down_state, btn_bank_left_state, btn_bank_right_state;
 	ubyte slide_on_state, bank_on_state;

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -976,8 +976,8 @@ void change_res()
 
 void input_config_sensitivity()
 {
-	newmenu_item m[36+8];
-	int i = 0, nitems = 0, keysens = 0, joysens = 0, joydead = 0, joyunder = 0, mousesens = 0, mousefsdead, mouseimpulse; /* Old school mouse */ 
+	newmenu_item m[36+8+8];
+	int i = 0, nitems = 0, keysens = 0, joysens = 0, joydead = 0, joyunder = 0, mousesens = 0, mouseoverrun = 0, mousefsdead, mouseimpulse; /* Old school mouse */ 
 
 	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = "Keyboard Sensitivity:"; nitems++;
 	keysens = nitems;
@@ -1022,6 +1022,15 @@ void input_config_sensitivity()
 	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_SLIDE_UD; m[nitems].value = PlayerCfg.MouseSens[3]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
 	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_BANK_LR; m[nitems].value = PlayerCfg.MouseSens[4]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
 	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_THROTTLE; m[nitems].value = PlayerCfg.MouseSens[5]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = ""; nitems++;	
+	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = "Mouse Overrun Buffer:"; nitems++;
+	mouseoverrun = nitems;
+	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_TURN_LR; m[nitems].value = PlayerCfg.MouseOverrun[0]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_PITCH_UD; m[nitems].value = PlayerCfg.MouseOverrun[1]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_SLIDE_LR; m[nitems].value = PlayerCfg.MouseOverrun[2]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_SLIDE_UD; m[nitems].value = PlayerCfg.MouseOverrun[3]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_BANK_LR; m[nitems].value = PlayerCfg.MouseOverrun[4]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_THROTTLE; m[nitems].value = PlayerCfg.MouseOverrun[5]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
 	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = ""; nitems++;
 	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = "Old School Mouse:"; nitems++;
 	mouseimpulse = nitems; 
@@ -1040,6 +1049,7 @@ void input_config_sensitivity()
 		PlayerCfg.JoystickSens[i] = m[joysens+i].value;
 		PlayerCfg.JoystickDead[i] = m[joydead+i].value;
 		PlayerCfg.MouseSens[i] = m[mousesens+i].value;
+        PlayerCfg.MouseOverrun[i] = m[mouseoverrun+i].value;
 		PlayerCfg.JoystickUndercalibrate[i] = m[joyunder+i].value;
 	}
 	PlayerCfg.MouseFSDead = m[mousefsdead].value;

--- a/d1/main/playsave.c
+++ b/d1/main/playsave.c
@@ -85,6 +85,7 @@ int new_player_config()
 	PlayerCfg.MouseControlStyle = MOUSE_CONTROL_OLDSCHOOL; /* Old School Mouse */
 	PlayerCfg.MouseImpulse = 8;
 	PlayerCfg.MouseSens[0] = PlayerCfg.MouseSens[1] = PlayerCfg.MouseSens[2] = PlayerCfg.MouseSens[3] = PlayerCfg.MouseSens[4] = PlayerCfg.MouseSens[5] = 8;
+    PlayerCfg.MouseOverrun[0] = PlayerCfg.MouseOverrun[1] = PlayerCfg.MouseOverrun[2] = PlayerCfg.MouseOverrun[3] = PlayerCfg.MouseOverrun[4] = PlayerCfg.MouseOverrun[5] = 0;
 	PlayerCfg.MouseFSDead = 0;
 	PlayerCfg.MouseFSIndicator = 1;
 	PlayerCfg.CockpitMode[0] = PlayerCfg.CockpitMode[1] = CM_FULL_COCKPIT;
@@ -293,6 +294,18 @@ int read_player_d1x(char *filename)
 					PlayerCfg.MouseSens[4] = atoi(line);
 				if(!strcmp(word,"SENSITIVITY5"))
 					PlayerCfg.MouseSens[5] = atoi(line);
+				if(!strcmp(word,"OVERRUN0"))
+					PlayerCfg.MouseOverrun[0] = atoi(line);
+				if(!strcmp(word,"OVERRUN1"))
+					PlayerCfg.MouseOverrun[1] = atoi(line);
+				if(!strcmp(word,"OVERRUN2"))
+					PlayerCfg.MouseOverrun[2] = atoi(line);
+				if(!strcmp(word,"OVERRUN3"))
+					PlayerCfg.MouseOverrun[3] = atoi(line);
+				if(!strcmp(word,"OVERRUN4"))
+					PlayerCfg.MouseOverrun[4] = atoi(line);
+				if(!strcmp(word,"OVERRUN5"))
+					PlayerCfg.MouseOverrun[5] = atoi(line);
 				if(!strcmp(word,"FSDEAD"))
 					PlayerCfg.MouseFSDead = atoi(line);
 				if(!strcmp(word,"FSINDI"))
@@ -713,6 +726,12 @@ int write_player_d1x(char *filename)
 		PHYSFSX_printf(fout,"sensitivity3=%d\n",PlayerCfg.MouseSens[3]);
 		PHYSFSX_printf(fout,"sensitivity4=%d\n",PlayerCfg.MouseSens[4]);
 		PHYSFSX_printf(fout,"sensitivity5=%d\n",PlayerCfg.MouseSens[5]);
+		PHYSFSX_printf(fout,"overrun0=%d\n",PlayerCfg.MouseOverrun[0]);
+		PHYSFSX_printf(fout,"overrun1=%d\n",PlayerCfg.MouseOverrun[1]);
+		PHYSFSX_printf(fout,"overrun2=%d\n",PlayerCfg.MouseOverrun[2]);
+		PHYSFSX_printf(fout,"overrun3=%d\n",PlayerCfg.MouseOverrun[3]);
+		PHYSFSX_printf(fout,"overrun4=%d\n",PlayerCfg.MouseOverrun[4]);
+		PHYSFSX_printf(fout,"overrun5=%d\n",PlayerCfg.MouseOverrun[5]);
 		PHYSFSX_printf(fout,"fsdead=%d\n",PlayerCfg.MouseFSDead);
 		PHYSFSX_printf(fout,"fsindi=%d\n",PlayerCfg.MouseFSIndicator);
 		PHYSFSX_printf(fout,"[end]\n");

--- a/d1/main/playsave.h
+++ b/d1/main/playsave.h
@@ -70,6 +70,7 @@ typedef struct player_config
 	ubyte MouseControlStyle; /* Old School Mouse -- ubyte MouseFlightSim; */ 
 	int MouseImpulse; /* Old School Mouse */ 
 	int MouseSens[6];
+    int MouseOverrun[6];
 	int MouseFSDead;
 	int MouseFSIndicator;
 	int CockpitMode[2]; // 0 saves the "real" cockpit, 1 also saves letterbox and rear. Used to properly switch between modes and restore the real one.

--- a/d2/main/kconfig.c
+++ b/d2/main/kconfig.c
@@ -1263,6 +1263,7 @@ void kconfig_read_controls(d_event *event, int automap_flag)
 {
 	int i = 0, j = 0, speed_factor = cheats.turbo?2:1;
 	static fix64 mouse_delta_time = 0;
+    int overruns = 0;
 
 #ifndef NDEBUG
 	// --- Don't do anything if in debug mode ---
@@ -1719,19 +1720,139 @@ void kconfig_read_controls(d_event *event, int automap_flag)
 	if (Cruise_speed < 0 ) Cruise_speed = 0;
 	if (Controls.forward_thrust_time==0) Controls.forward_thrust_time = fixmul(Cruise_speed,FrameTime)/100;
 
-	//----------- Clamp values between -FrameTime and FrameTime
-	if (Controls.pitch_time > FrameTime/2 ) Controls.pitch_time = FrameTime/2;
-	if (Controls.heading_time > FrameTime ) Controls.heading_time = FrameTime;
-	if (Controls.pitch_time < -FrameTime/2 ) Controls.pitch_time = -FrameTime/2;
-	if (Controls.heading_time < -FrameTime ) Controls.heading_time = -FrameTime;
-	if (Controls.vertical_thrust_time > FrameTime ) Controls.vertical_thrust_time = FrameTime;
-	if (Controls.sideways_thrust_time > FrameTime ) Controls.sideways_thrust_time = FrameTime;
-	if (Controls.bank_time > FrameTime ) Controls.bank_time = FrameTime;
-	if (Controls.forward_thrust_time > FrameTime ) Controls.forward_thrust_time = FrameTime;
-	if (Controls.vertical_thrust_time < -FrameTime ) Controls.vertical_thrust_time = -FrameTime;
-	if (Controls.sideways_thrust_time < -FrameTime ) Controls.sideways_thrust_time = -FrameTime;
-	if (Controls.bank_time < -FrameTime ) Controls.bank_time = -FrameTime;
-	if (Controls.forward_thrust_time < -FrameTime ) Controls.forward_thrust_time = -FrameTime;
+    //----------- Add overrun values
+    Controls.pitch_time += Controls.pitch_time_overrun;
+    Controls.heading_time += Controls.heading_time_overrun;
+    Controls.vertical_thrust_time += Controls.vertical_thrust_time_overrun;
+    Controls.sideways_thrust_time += Controls.sideways_thrust_time_overrun;
+    Controls.bank_time += Controls.bank_time_overrun;
+    Controls.forward_thrust_time += Controls.forward_thrust_time_overrun;
+    
+    //----------- Set a flag to indicate whether there was an overrun for each of the values
+    overruns |= (Controls.pitch_time_overrun ? 1 : 0);
+    overruns |= (Controls.heading_time_overrun ? 2 : 0);
+    overruns |= (Controls.vertical_thrust_time_overrun ? 4 : 0);
+    overruns |= (Controls.sideways_thrust_time_overrun ? 8 : 0);
+    overruns |= (Controls.bank_time_overrun ? 16 : 0);
+    overruns |= (Controls.forward_thrust_time_overrun ? 32 : 0);
+    
+    //----------- Clear overrun values
+    Controls.pitch_time_overrun = 0;
+    Controls.heading_time_overrun = 0;
+    Controls.vertical_thrust_time_overrun = 0;
+    Controls.sideways_thrust_time_overrun = 0;
+    Controls.bank_time_overrun = 0;
+    Controls.forward_thrust_time_overrun = 0;
+
+    //----------- Clamp values between -FrameTime and FrameTime
+    if (Controls.pitch_time > FrameTime/2 ) {
+        if (overruns & 1 || (!Controls.slide_on_state && Controls.mouse_axis[kc_mouse[13].value])) {
+            Controls.pitch_time_overrun += (Controls.pitch_time - FrameTime/2);
+            if (Controls.pitch_time_overrun > F1_0 * PlayerCfg.MouseOverrun[1] / 32) {
+                Controls.pitch_time_overrun = F1_0 * PlayerCfg.MouseOverrun[1] / 32;
+            }
+        }
+        Controls.pitch_time = FrameTime/2;
+    }
+    if (Controls.heading_time > FrameTime ) {
+        if (overruns & 2 || (!Controls.slide_on_state && !Controls.bank_on_state && Controls.mouse_axis[kc_mouse[15].value])) {
+            Controls.heading_time_overrun += (Controls.heading_time - FrameTime);
+            if (Controls.heading_time_overrun > F1_0 * PlayerCfg.MouseOverrun[0] / 16) {
+                Controls.heading_time_overrun = F1_0 * PlayerCfg.MouseOverrun[0] / 16;
+            }
+        }
+        Controls.heading_time = FrameTime;
+    }
+    if (Controls.pitch_time < -FrameTime/2 ) {
+        if (overruns & 1 || (!Controls.slide_on_state && Controls.mouse_axis[kc_mouse[13].value])) {
+            Controls.pitch_time_overrun += (Controls.pitch_time + FrameTime/2);
+            if (Controls.pitch_time_overrun < F1_0 * -PlayerCfg.MouseOverrun[1] / 32) {
+                Controls.pitch_time_overrun = F1_0 * -PlayerCfg.MouseOverrun[1] / 32;
+            }
+        }
+        Controls.pitch_time = -FrameTime/2;
+    }
+    if (Controls.heading_time < -FrameTime ) {
+        if (overruns & 2 || (!Controls.slide_on_state && !Controls.bank_on_state && Controls.mouse_axis[kc_mouse[15].value])) {
+            Controls.heading_time_overrun += (Controls.heading_time + FrameTime);
+            if (Controls.heading_time_overrun < F1_0 * -PlayerCfg.MouseOverrun[0] / 16) {
+                Controls.heading_time_overrun = F1_0 * -PlayerCfg.MouseOverrun[0] / 16;
+            }
+        }
+        Controls.heading_time = -FrameTime;
+    }
+    if (Controls.vertical_thrust_time > FrameTime ) {
+        if (overruns & 4 || (Controls.mouse_axis[kc_mouse[19].value] || (Controls.slide_on_state && Controls.mouse_axis[kc_mouse[13].value]))) {
+            Controls.vertical_thrust_time_overrun += (Controls.vertical_thrust_time - FrameTime);
+            if (Controls.vertical_thrust_time_overrun > F1_0 * PlayerCfg.MouseOverrun[3] / 16) {
+                Controls.vertical_thrust_time_overrun = F1_0 * PlayerCfg.MouseOverrun[3] / 16;
+            }
+        }
+        Controls.vertical_thrust_time = FrameTime;
+    }
+    if (Controls.sideways_thrust_time > FrameTime ) {
+        if (overruns & 8 || (Controls.mouse_axis[kc_mouse[17].value] || (Controls.slide_on_state && Controls.mouse_axis[kc_mouse[15].value]))) {
+            Controls.sideways_thrust_time_overrun += (Controls.sideways_thrust_time - FrameTime);
+            if (Controls.sideways_thrust_time_overrun > F1_0 * PlayerCfg.MouseOverrun[2] / 16) {
+                Controls.sideways_thrust_time_overrun = F1_0 * PlayerCfg.MouseOverrun[2] / 16;
+            }
+        }
+        Controls.sideways_thrust_time = FrameTime;
+    }
+    if (Controls.bank_time > FrameTime ) {
+        if (overruns & 16 || (Controls.mouse_axis[kc_mouse[21].value] || (Controls.bank_on_state && Controls.mouse_axis[kc_mouse[15].value]))) {
+            Controls.bank_time_overrun += (Controls.bank_time - FrameTime);
+            if (Controls.bank_time_overrun > F1_0 * PlayerCfg.MouseOverrun[4] / 16) {
+                Controls.bank_time_overrun = F1_0 * PlayerCfg.MouseOverrun[4] / 16;
+            }
+        }
+        Controls.bank_time = FrameTime;
+    }
+    if (Controls.forward_thrust_time > FrameTime ) {
+        if (overruns & 32 || (Controls.mouse_axis[kc_mouse[23].value])) {
+            Controls.forward_thrust_time_overrun += (Controls.forward_thrust_time - FrameTime);
+            if (Controls.forward_thrust_time_overrun > F1_0 * PlayerCfg.MouseOverrun[5] / 16) {
+                Controls.forward_thrust_time_overrun = F1_0 * PlayerCfg.MouseOverrun[5] / 16;
+            }
+        }
+        Controls.forward_thrust_time = FrameTime;
+    }
+    if (Controls.vertical_thrust_time < -FrameTime ) {
+        if (overruns & 4 || (Controls.mouse_axis[kc_mouse[19].value] || (Controls.slide_on_state && Controls.mouse_axis[kc_mouse[13].value]))) {
+            Controls.vertical_thrust_time_overrun += (Controls.vertical_thrust_time + FrameTime);
+            if (Controls.vertical_thrust_time_overrun < F1_0 * -PlayerCfg.MouseOverrun[3] / 16) {
+                Controls.vertical_thrust_time_overrun = F1_0 * -PlayerCfg.MouseOverrun[3] / 16;
+            }
+        }
+        Controls.vertical_thrust_time = -FrameTime;
+    }
+    if (Controls.sideways_thrust_time < -FrameTime ) {
+        if (overruns & 8 || (Controls.mouse_axis[kc_mouse[17].value] || (Controls.slide_on_state && Controls.mouse_axis[kc_mouse[15].value]))) {
+            Controls.sideways_thrust_time_overrun += (Controls.sideways_thrust_time + FrameTime);
+            if (Controls.sideways_thrust_time_overrun < F1_0 * -PlayerCfg.MouseOverrun[2] / 16) {
+                Controls.sideways_thrust_time_overrun = F1_0 * -PlayerCfg.MouseOverrun[2] / 16;
+            }
+        }
+        Controls.sideways_thrust_time = -FrameTime;
+    }
+    if (Controls.bank_time < -FrameTime ) {
+        if (overruns & 16 || (Controls.mouse_axis[kc_mouse[21].value] || (Controls.bank_on_state && Controls.mouse_axis[kc_mouse[15].value]))) {
+            Controls.bank_time_overrun += (Controls.bank_time + FrameTime);
+            if (Controls.bank_time_overrun < F1_0 * -PlayerCfg.MouseOverrun[4] / 16) {
+                Controls.bank_time_overrun = F1_0 * -PlayerCfg.MouseOverrun[4] / 16;
+            }
+        }
+        Controls.bank_time = -FrameTime;
+    }
+    if (Controls.forward_thrust_time < -FrameTime ) {
+        if (overruns & 32 || (Controls.mouse_axis[kc_mouse[23].value])) {
+            Controls.forward_thrust_time_overrun += (Controls.forward_thrust_time + FrameTime);
+            if (Controls.forward_thrust_time_overrun < F1_0 * -PlayerCfg.MouseOverrun[5] / 16) {
+                Controls.forward_thrust_time_overrun = F1_0 * -PlayerCfg.MouseOverrun[5] / 16;
+            }
+        }
+        Controls.forward_thrust_time = -FrameTime;
+    }
 }
 
 void reset_cruise(void)

--- a/d2/main/kconfig.h
+++ b/d2/main/kconfig.h
@@ -30,6 +30,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 typedef struct _control_info {
 	float key_pitch_forward_down_time, key_pitch_backward_down_time, key_heading_left_down_time, key_heading_right_down_time, key_slide_left_down_time, key_slide_right_down_time, key_slide_up_down_time, key_slide_down_down_time, key_bank_left_down_time, key_bank_right_down_time; // to scale movement depending on how long the key is pressed
 	fix pitch_time, vertical_thrust_time, heading_time, sideways_thrust_time, bank_time, forward_thrust_time;
+    fix pitch_time_overrun, vertical_thrust_time_overrun, heading_time_overrun, sideways_thrust_time_overrun, bank_time_overrun, forward_thrust_time_overrun;
 	ubyte key_pitch_forward_state, key_pitch_backward_state, key_heading_left_state, key_heading_right_state, key_slide_left_state, key_slide_right_state, key_slide_up_state, key_slide_down_state, key_bank_left_state, key_bank_right_state; // to scale movement for keys only we need them to be seperate from joystick/mouse buttons
 	ubyte btn_slide_left_state, btn_slide_right_state, btn_slide_up_state, btn_slide_down_state, btn_bank_left_state, btn_bank_right_state;
 	ubyte slide_on_state, bank_on_state;

--- a/d2/main/menu.c
+++ b/d2/main/menu.c
@@ -1000,8 +1000,8 @@ void change_res()
 
 void input_config_sensitivity()
 {
-	newmenu_item m[36+8];
-	int i = 0, nitems = 0, keysens = 0, joysens = 0, joydead = 0, joyunder = 0, mousesens = 0, mousefsdead, mouseimpulse; /* Old school mouse */ 
+    newmenu_item m[36+8+8];
+    int i = 0, nitems = 0, keysens = 0, joysens = 0, joydead = 0, joyunder = 0, mousesens = 0, mouseoverrun = 0, mousefsdead, mouseimpulse; /* Old school mouse */ 
 
 	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = "Keyboard Sensitivity:"; nitems++;
 	keysens = nitems;
@@ -1046,6 +1046,15 @@ void input_config_sensitivity()
 	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_SLIDE_UD; m[nitems].value = PlayerCfg.MouseSens[3]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
 	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_BANK_LR; m[nitems].value = PlayerCfg.MouseSens[4]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
 	m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_THROTTLE; m[nitems].value = PlayerCfg.MouseSens[5]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+    m[nitems].type = NM_TYPE_TEXT; m[nitems].text = ""; nitems++;    
+    m[nitems].type = NM_TYPE_TEXT; m[nitems].text = "Mouse Overrun Buffer:"; nitems++;
+    mouseoverrun = nitems;
+    m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_TURN_LR; m[nitems].value = PlayerCfg.MouseOverrun[0]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+    m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_PITCH_UD; m[nitems].value = PlayerCfg.MouseOverrun[1]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+    m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_SLIDE_LR; m[nitems].value = PlayerCfg.MouseOverrun[2]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+    m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_SLIDE_UD; m[nitems].value = PlayerCfg.MouseOverrun[3]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+    m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_BANK_LR; m[nitems].value = PlayerCfg.MouseOverrun[4]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
+    m[nitems].type = NM_TYPE_SLIDER; m[nitems].text = TXT_THROTTLE; m[nitems].value = PlayerCfg.MouseOverrun[5]; m[nitems].min_value = 0; m[nitems].max_value = 16; nitems++;
 	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = ""; nitems++;
 	m[nitems].type = NM_TYPE_TEXT; m[nitems].text = "Old School Mouse:"; nitems++;
 	mouseimpulse = nitems; 
@@ -1064,6 +1073,7 @@ void input_config_sensitivity()
 		PlayerCfg.JoystickSens[i] = m[joysens+i].value;
 		PlayerCfg.JoystickDead[i] = m[joydead+i].value;
 		PlayerCfg.MouseSens[i] = m[mousesens+i].value;
+        PlayerCfg.MouseOverrun[i] = m[mouseoverrun+i].value;
 		PlayerCfg.JoystickUndercalibrate[i] = m[joyunder+i].value;
 	}
 	PlayerCfg.MouseFSDead = m[mousefsdead].value;

--- a/d2/main/playsave.c
+++ b/d2/main/playsave.c
@@ -100,6 +100,7 @@ int new_player_config()
 	PlayerCfg.MouseControlStyle = MOUSE_CONTROL_OLDSCHOOL; /* Old School Mouse */
 	PlayerCfg.MouseImpulse = 8;
 	PlayerCfg.MouseSens[0] = PlayerCfg.MouseSens[1] = PlayerCfg.MouseSens[2] = PlayerCfg.MouseSens[3] = PlayerCfg.MouseSens[4] = PlayerCfg.MouseSens[5] = 8;
+    PlayerCfg.MouseOverrun[0] = PlayerCfg.MouseOverrun[1] = PlayerCfg.MouseOverrun[2] = PlayerCfg.MouseOverrun[3] = PlayerCfg.MouseOverrun[4] = PlayerCfg.MouseOverrun[5] = 0;
 	PlayerCfg.MouseFSDead = 0;
 	PlayerCfg.MouseFSIndicator = 1;
 	PlayerCfg.CockpitMode[0] = PlayerCfg.CockpitMode[1] = CM_FULL_COCKPIT;
@@ -265,6 +266,18 @@ int read_player_d2x(char *filename)
 					PlayerCfg.MouseSens[4] = atoi(line);
 				if(!strcmp(word,"SENSITIVITY5"))
 					PlayerCfg.MouseSens[5] = atoi(line);
+                if(!strcmp(word,"OVERRUN0"))
+                    PlayerCfg.MouseOverrun[0] = atoi(line);
+                if(!strcmp(word,"OVERRUN1"))
+                    PlayerCfg.MouseOverrun[1] = atoi(line);
+                if(!strcmp(word,"OVERRUN2"))
+                    PlayerCfg.MouseOverrun[2] = atoi(line);
+                if(!strcmp(word,"OVERRUN3"))
+                    PlayerCfg.MouseOverrun[3] = atoi(line);
+                if(!strcmp(word,"OVERRUN4"))
+                    PlayerCfg.MouseOverrun[4] = atoi(line);
+                if(!strcmp(word,"OVERRUN5"))
+                    PlayerCfg.MouseOverrun[5] = atoi(line);
 				if(!strcmp(word,"FSDEAD"))
 					PlayerCfg.MouseFSDead = atoi(line);
 				if(!strcmp(word,"FSINDI"))
@@ -500,6 +513,12 @@ int write_player_d2x(char *filename)
 		PHYSFSX_printf(fout,"sensitivity3=%d\n",PlayerCfg.MouseSens[3]);
 		PHYSFSX_printf(fout,"sensitivity4=%d\n",PlayerCfg.MouseSens[4]);
 		PHYSFSX_printf(fout,"sensitivity5=%d\n",PlayerCfg.MouseSens[5]);
+        PHYSFSX_printf(fout,"overrun0=%d\n",PlayerCfg.MouseOverrun[0]);
+        PHYSFSX_printf(fout,"overrun1=%d\n",PlayerCfg.MouseOverrun[1]);
+        PHYSFSX_printf(fout,"overrun2=%d\n",PlayerCfg.MouseOverrun[2]);
+        PHYSFSX_printf(fout,"overrun3=%d\n",PlayerCfg.MouseOverrun[3]);
+        PHYSFSX_printf(fout,"overrun4=%d\n",PlayerCfg.MouseOverrun[4]);
+        PHYSFSX_printf(fout,"overrun5=%d\n",PlayerCfg.MouseOverrun[5]);
 		PHYSFSX_printf(fout,"fsdead=%d\n",PlayerCfg.MouseFSDead);
 		PHYSFSX_printf(fout,"fsindi=%d\n",PlayerCfg.MouseFSIndicator);
 		PHYSFSX_printf(fout,"[end]\n");

--- a/d2/main/playsave.h
+++ b/d2/main/playsave.h
@@ -57,6 +57,7 @@ typedef struct player_config
 	ubyte MouseControlStyle; /* Old School Mouse -- ubyte MouseFlightSim; */ 
 	int MouseImpulse; /* Old School Mouse */ 
 	int MouseSens[6];
+    int MouseOverrun[6];
 	int MouseFSDead;
 	int MouseFSIndicator;
 	int CockpitMode[2]; // 0 saves the "real" cockpit, 1 also saves letterbox and rear. Used to properly switch between modes and restore the real one.


### PR DESCRIPTION
Adds a new "mouse overrun buffer" setting.  The mouse overrun buffer setting takes extra movement in a frame beyond the maximum allowed movement and stores it.  It will store between zero and one second of movement, depending on the setting.  The default setting is zero, which means no change to mouse settings.  This setting should only affect old school and rebirth mouse controls.
