### PR TITLE
Fix physfsrwops.h for newer physfs

### DIFF
--- a/d2/include/physfsrwops.h
+++ b/d2/include/physfsrwops.h
@@ -44,7 +44,7 @@ extern "C" {
  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
  *           of the error can be gleaned from PHYSFS_getLastError().
  */
-__EXPORT__ SDL_RWops *PHYSFSRWOPS_openRead(const char *fname);
+ SDL_RWops *PHYSFSRWOPS_openRead(const char *fname);
 
 /**
  * Open a platform-independent filename for writing, and make it accessible
@@ -56,7 +56,7 @@ __EXPORT__ SDL_RWops *PHYSFSRWOPS_openRead(const char *fname);
  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
  *           of the error can be gleaned from PHYSFS_getLastError().
  */
-__EXPORT__ SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname);
+ SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname);
 
 /**
  * Open a platform-independent filename for appending, and make it accessible
@@ -68,7 +68,7 @@ __EXPORT__ SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname);
  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
  *           of the error can be gleaned from PHYSFS_getLastError().
  */
-__EXPORT__ SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname);
+ SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname);
 
 /**
  * Make a SDL_RWops from an existing PhysicsFS file handle. You should
@@ -80,7 +80,7 @@ __EXPORT__ SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname);
  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
  *           of the error can be gleaned from PHYSFS_getLastError().
  */
-__EXPORT__ SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_file *handle);
+ SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_file *handle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Physfs 3 removes the __EXPORT__ macro. __EXPORT__ is not be needed here since there is no library created.