### PR TITLE
Use SDL_AudioCVT len_cvt and fix mem leak

### DIFF
--- a/d1/arch/sdl/digi_mixer.c
+++ b/d1/arch/sdl/digi_mixer.c
@@ -123,7 +123,7 @@ void mixdigi_convert_sound(int i)
 		if (SDL_ConvertAudio(&cvt)) con_printf(CON_DEBUG,"conversion of %d failed\n", i);
 
 		SoundChunks[i].abuf = cvt.buf;
-		SoundChunks[i].alen = dlen * cvt.len_mult;
+		SoundChunks[i].alen = cvt.len_cvt;
 		SoundChunks[i].allocated = 1;
 		SoundChunks[i].volume = 128; // Max volume = 128
 	}

--- a/d2/arch/sdl/digi_mixer.c
+++ b/d2/arch/sdl/digi_mixer.c
@@ -128,7 +128,7 @@ void mixdigi_convert_sound(int i)
 		if (SDL_ConvertAudio(&cvt)) con_printf(CON_DEBUG,"conversion of %d failed\n", i);
 
 		SoundChunks[i].abuf = cvt.buf;
-		SoundChunks[i].alen = dlen * cvt.len_mult;
+		SoundChunks[i].alen = cvt.len_cvt;
 		SoundChunks[i].allocated = 1;
 		SoundChunks[i].volume = 128; // Max volume = 128
 	}

--- a/d2/libmve/mveplay.c
+++ b/d2/libmve/mveplay.c
@@ -488,9 +488,9 @@ static int audio_data_handler(unsigned char major, unsigned char minor, unsigned
 
 				// copy back to the audio buffer
 				mve_free(mve_audio_buffers[mve_audio_buftail]); // free the old audio buffer
-				mve_audio_buflens[mve_audio_buftail] = clen;
-				mve_audio_buffers[mve_audio_buftail] = (short *)mve_alloc(clen);
-				memcpy(mve_audio_buffers[mve_audio_buftail], cvt.buf, clen);
+				mve_audio_buflens[mve_audio_buftail] = cvt.len_cvt;
+				mve_audio_buffers[mve_audio_buftail] = (short *)mve_alloc(cvt.len_cvt);
+				memcpy(mve_audio_buffers[mve_audio_buftail], cvt.buf, cvt.len_cvt);
 			}
 #endif
 

--- a/d2/libmve/mveplay.c
+++ b/d2/libmve/mveplay.c
@@ -491,6 +491,7 @@ static int audio_data_handler(unsigned char major, unsigned char minor, unsigned
 				mve_audio_buflens[mve_audio_buftail] = cvt.len_cvt;
 				mve_audio_buffers[mve_audio_buftail] = (short *)mve_alloc(cvt.len_cvt);
 				memcpy(mve_audio_buffers[mve_audio_buftail], cvt.buf, cvt.len_cvt);
+				free(cvt.buf);
 			}
 #endif
 


### PR DESCRIPTION
The len_mult field might be too large when sdl12-compat is used.