### PR TITLE
Fix D2 homer speed

### DIFF
--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -1526,7 +1526,7 @@ void Laser_do_weapon_sequence(object *obj, int doHomerFrame, fix idealHomerFrame
 					} 
 				}
 				if (speed+F1_0 < max_speed) {
-					speed += fixmul(max_speed, FrameTime/2);
+					speed += fixmul(max_speed, idealHomerFrameTime/2);
 					if (speed > max_speed)
 						speed = max_speed;
 				}


### PR DESCRIPTION
The D2 code used the actual FrameTime instead of the idealHomerFrameTime for a homing speed calculation.