### PR TITLE
Fix SConstruct for scons 4.5+

### DIFF
--- a/d1/SConstruct
+++ b/d1/SConstruct
@@ -371,7 +371,7 @@ class DXXProgram(DXXCommon):
 		objects = [self.env.StaticObject(target='%s%s%s' % (self.user_settings.builddir, os.path.splitext(s)[0], self.env["OBJSUFFIX"]), source=s) for s in self.common_sources]
 		objects.extend(self.platform_settings.platform_objects)
 		objects.extend(program_specific_objects)
-		versid_cppdefines=env['CPPDEFINES'][:]
+		versid_cppdefines=list(env['CPPDEFINES'])
 		if self.user_settings.extra_version:
 			versid_cppdefines.append(('DESCENT_VERSION_EXTRA', '\\"%s\\"' % self.user_settings.extra_version))
 		objects.append(self.env.StaticObject(target='%s%s%s' % (self.user_settings.builddir, 'main/vers_id', self.env["OBJSUFFIX"]), source='main/vers_id.c', CPPDEFINES=versid_cppdefines))

--- a/d2/SConstruct
+++ b/d2/SConstruct
@@ -372,7 +372,7 @@ class DXXProgram(DXXCommon):
 		objects = [self.env.StaticObject(target='%s%s%s' % (self.user_settings.builddir, os.path.splitext(s)[0], self.env["OBJSUFFIX"]), source=s) for s in self.common_sources]
 		objects.extend(self.platform_settings.platform_objects)
 		objects.extend(program_specific_objects)
-		versid_cppdefines=env['CPPDEFINES'][:]
+		versid_cppdefines=list(env['CPPDEFINES'])
 		if self.user_settings.program_name:
 			exe_target = self.user_settings.program_name
 		if self.user_settings.extra_version:


### PR DESCRIPTION
In scons 4.5+ env['CPPDEFINES'] can sometimes return a deque object (see SCons/scons#4321). Convert it to a list where needed.